### PR TITLE
bump release-it version

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kasadev/keep-a-changelog",
-  "version": "4.3.0",
+  "version": "4.4.0",
   "description": "Keep-a-changelog plugin for release-it",
   "type": "module",
   "exports": "./index.js",
@@ -36,11 +36,11 @@
   "devDependencies": {
     "bron": "^2.0.3",
     "mock-fs": "^5.5.0",
-    "release-it": "^19.0.1",
+    "release-it": "^20.0.1",
     "sinon": "^20.0.0"
   },
   "peerDependencies": {
-    "release-it": "^19.0.1"
+    "release-it": "^20.0.1"
   },
   "engines": {
     "node": ">=18"

--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
     "release-it": "^20.0.1"
   },
   "engines": {
-    "node": ">=18"
+    "node": ">=20"
   },
   "release-it": {
     "github": {


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Moderate risk because it changes peer compatibility (`release-it` v19→v20) and raises the minimum Node version, which may break consumers pinned to older tooling.
> 
> **Overview**
> Updates package metadata for a new release: bumps the plugin version to `4.4.0`, upgrades `release-it` in both `devDependencies` and `peerDependencies` to `^20.0.1`, and raises the supported Node.js engine from `>=18` to `>=20`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit eeff2c044b8593137ffa31a114a12aa53bdea4c0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->